### PR TITLE
Transcode WAV to AAC for HLS

### DIFF
--- a/.github/workflows/concat-upload.yml
+++ b/.github/workflows/concat-upload.yml
@@ -263,7 +263,7 @@ jobs:
         if: env.SKIP_CHUNK_PROCESSING != 'true'
         run: |
           mkdir -p hls
-          ffmpeg -y -i full_upload.$EXTENSION -codec:a aac -b:a 128k -f hls -hls_time 10 -hls_playlist_type vod -hls_segment_filename "hls/segment%03d.aac" hls/playlist.m3u8
+          ffmpeg -y -i full_upload.$EXTENSION -c:a aac -b:a 128k -movflags +faststart -f hls -hls_time 6 -hls_segment_type fmp4 -hls_playlist_type vod -hls_segment_filename "hls/segment%03d.m4s" hls/playlist.m3u8
 
       - name: Upload HLS files to Cloudinary
         if: env.SKIP_CHUNK_PROCESSING != 'true'


### PR DESCRIPTION
Update HLS audio conversion to use fMP4 segments for broader compatibility.

This fixes `DEMUXER_ERROR_COULD_NOT_PARSE` on mobile browsers by ensuring AAC audio is packaged in fMP4 containers, which is required for Media Source Extensions (MSE) support.

---

[Slack Thread](https://theaiinc.slack.com/archives/D094HVALEJW/p1752454058560139?thread_ts=1752454058.560139&cid=D094HVALEJW)